### PR TITLE
Add best_val update in BestResultLogger callback

### DIFF
--- a/hopt/keras.py
+++ b/hopt/keras.py
@@ -253,6 +253,7 @@ class BestResultLogger(Callback):
     def on_epoch_end(self, batch, logs=()):
         if not self.best_val or self.metric_improved(logs[self.monitored_metric], self.best_val):
             self.best = dict(logs)
+            self.best_val = logs[self.monitored_metric]
             print("Best result: ", self.best)
             with open(self.file_path, 'w') as f:
                 json.dump(self.best, f, indent=4, cls=self.NumpyEncoder)


### PR DESCRIPTION
Curently BestResultLogger::best_val is always None,  which results in updating BestResultLogger::best every epoch. This causes print("Best result:") every epoch. After training, the result saved to results/TIMESTAMP.json is the last result instead of the best result.